### PR TITLE
Update extension for OpenAI client compatibility

### DIFF
--- a/MIGRATION_v0.14.0.md
+++ b/MIGRATION_v0.14.0.md
@@ -10,12 +10,14 @@ This document outlines the changes made to upgrade the Flarum extension to be co
 ### 2. API Migration
 - **Completions API → Chat Completions API**: Migrated from the deprecated `completions()` endpoint to the new `chat()->completions()` endpoint
 - **Prompt Format**: Changed from string prompts to structured message arrays with roles
-- **Model Update**: Default model changed from `text-davinci-003` to `gpt-3.5-turbo`
+- **Model Update**: Default model changed from `text-davinci-003` to `gpt-3.5-turbo` (configurable via settings)
 
 ### 3. Code Changes
 
 #### OpenAIClient.php
 - Migrated `$client->completions()->create()` to `$client->chat()->completions()->create()`
+- **Dynamic Model Selection**: Model is now read from settings instead of being hard-coded
+- **Configurable Parameters**: `max_tokens` and `temperature` are now configurable via settings
 - Updated prompt format to use messages array:
   ```php
   'messages' => [
@@ -33,31 +35,54 @@ This document outlines the changes made to upgrade the Flarum extension to be co
 
 ### 4. Service Registration
 - Added proper dependency injection for `OpenAIClient` in `extend.php`
+- OpenAIClient now receives `SettingsRepositoryInterface` to read configuration
 - Updated default model setting to `gpt-3.5-turbo`
+- Added new setting: `datlechin-chatgpt.temperature` (default: 0.7)
 
-### 5. Breaking Changes
+### 5. Settings Configuration
+The extension now supports the following configurable settings:
+
+- `datlechin-chatgpt.model` - OpenAI model to use (default: `gpt-3.5-turbo`)
+- `datlechin-chatgpt.max_tokens` - Maximum tokens for responses (default: 100)
+- `datlechin-chatgpt.temperature` - Response creativity level (default: 0.7)
+
+### 6. Breaking Changes
 - The `completions()` method now returns an array instead of a string
 - All code consuming the API responses needed to be updated to handle the new structure
 - Model names and capabilities changed with the move to Chat Completions API
+- OpenAIClient constructor now requires SettingsRepositoryInterface
 
 ## What You Need to Do
 
 1. **Update Dependencies**: Run `composer update` to install the new OpenAI client version
-2. **Clear Cache**: Clear any cached model data as the API structure has changed
-3. **Test Functionality**: Verify that ChatGPT responses are working correctly with the new API
+2. **Configure Models**: You can now configure which OpenAI model to use in the admin panel
+3. **Adjust Settings**: Configure `max_tokens` and `temperature` according to your needs
+4. **Clear Cache**: Clear any cached model data as the API structure has changed
+5. **Test Functionality**: Verify that ChatGPT responses are working correctly with the new API
+
+## Supported Models
+
+With the new Chat Completions API, you can use modern models such as:
+- `gpt-3.5-turbo` (default, fast and cost-effective)
+- `gpt-3.5-turbo-16k` (larger context window)
+- `gpt-4` (more capable, requires API access)
+- `gpt-4-turbo-preview` (latest GPT-4 model)
 
 ## Benefits of the Migration
 
 - **Future-Proof**: Uses the current OpenAI API that's actively maintained
+- **Configurable**: Model selection and parameters can be changed via admin settings
 - **Better Models**: Access to newer, more capable models like GPT-3.5 Turbo and GPT-4
 - **Improved Performance**: Chat Completions API is optimized for conversational use cases
 - **Enhanced Features**: Better support for context and multi-turn conversations
+- **Flexible Configuration**: Easily adjust response parameters without code changes
 
 ## Troubleshooting
 
 If you encounter issues:
 
 1. Ensure your OpenAI API key is still valid
-2. Check that the new model (`gpt-3.5-turbo`) is available in your OpenAI account
+2. Check that the selected model is available in your OpenAI account
 3. Verify that your API usage limits haven't been exceeded
 4. Clear the extension cache if model listing fails
+5. Check the admin panel for proper model configuration

--- a/MIGRATION_v0.14.0.md
+++ b/MIGRATION_v0.14.0.md
@@ -1,0 +1,63 @@
+# Migration to OpenAI Client v0.14.0
+
+This document outlines the changes made to upgrade the Flarum extension to be compatible with OpenAI PHP client v0.14.0.
+
+## Key Changes Made
+
+### 1. Updated Dependencies
+- Updated `composer.json` to use `"openai-php/client": "^0.14.0"`
+
+### 2. API Migration
+- **Completions API → Chat Completions API**: Migrated from the deprecated `completions()` endpoint to the new `chat()->completions()` endpoint
+- **Prompt Format**: Changed from string prompts to structured message arrays with roles
+- **Model Update**: Default model changed from `text-davinci-003` to `gpt-3.5-turbo`
+
+### 3. Code Changes
+
+#### OpenAIClient.php
+- Migrated `$client->completions()->create()` to `$client->chat()->completions()->create()`
+- Updated prompt format to use messages array:
+  ```php
+  'messages' => [
+      [
+          'role' => 'user',
+          'content' => $prompt,
+      ],
+  ]
+  ```
+- Response handling updated to access `$response['choices'][0]['message']['content']`
+
+#### Response Structure Changes
+- **Old**: `$result->choices[0]->text`
+- **New**: `$response['choices'][0]['message']['content']`
+
+### 4. Service Registration
+- Added proper dependency injection for `OpenAIClient` in `extend.php`
+- Updated default model setting to `gpt-3.5-turbo`
+
+### 5. Breaking Changes
+- The `completions()` method now returns an array instead of a string
+- All code consuming the API responses needed to be updated to handle the new structure
+- Model names and capabilities changed with the move to Chat Completions API
+
+## What You Need to Do
+
+1. **Update Dependencies**: Run `composer update` to install the new OpenAI client version
+2. **Clear Cache**: Clear any cached model data as the API structure has changed
+3. **Test Functionality**: Verify that ChatGPT responses are working correctly with the new API
+
+## Benefits of the Migration
+
+- **Future-Proof**: Uses the current OpenAI API that's actively maintained
+- **Better Models**: Access to newer, more capable models like GPT-3.5 Turbo and GPT-4
+- **Improved Performance**: Chat Completions API is optimized for conversational use cases
+- **Enhanced Features**: Better support for context and multi-turn conversations
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Ensure your OpenAI API key is still valid
+2. Check that the new model (`gpt-3.5-turbo`) is available in your OpenAI account
+3. Verify that your API usage limits haven't been exceeded
+4. Clear the extension cache if model listing fails

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.1",
         "flarum/core": "^1.8.5",
-        "openai-php/client": "^0.10.1"
+        "openai-php/client": "^0.14.0"
     },
     "authors": [
         {

--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,7 @@ namespace Datlechin\FlarumChatGPT;
 
 use Datlechin\FlarumChatGPT\Access\DiscussionPolicy;
 use Datlechin\FlarumChatGPT\Listener\PostChatGPTAnswer;
+use Flarum\OpenAI\OpenAIClient;
 use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Event\Started;
 use Flarum\Extend;
@@ -31,8 +32,22 @@ return [
 
     new Extend\Locales(__DIR__.'/locale'),
 
+    (new Extend\ServiceProvider())
+        ->register(function ($container) {
+            $container->singleton(OpenAIClient::class, function ($container) {
+                $settings = $container->make('Flarum\Settings\SettingsRepositoryInterface');
+                $apiKey = $settings->get('datlechin-chatgpt.api_key');
+                
+                if (empty($apiKey)) {
+                    throw new \Exception('OpenAI API key is not set.');
+                }
+                
+                return new OpenAIClient($apiKey);
+            });
+        }),
+
     (new Extend\Settings())
-        ->default('datlechin-chatgpt.model', 'text-davinci-003')
+        ->default('datlechin-chatgpt.model', 'gpt-3.5-turbo')
         ->default('datlechin-chatgpt.enable_on_discussion_started', true)
         ->default('datlechin-chatgpt.max_tokens', 100)
         ->default('datlechin-chatgpt.user_prompt_badge_text', 'Assistant')

--- a/extend.php
+++ b/extend.php
@@ -42,7 +42,7 @@ return [
                     throw new \Exception('OpenAI API key is not set.');
                 }
                 
-                return new OpenAIClient($apiKey);
+                return new OpenAIClient($apiKey, $settings);
             });
         }),
 
@@ -50,6 +50,7 @@ return [
         ->default('datlechin-chatgpt.model', 'gpt-3.5-turbo')
         ->default('datlechin-chatgpt.enable_on_discussion_started', true)
         ->default('datlechin-chatgpt.max_tokens', 100)
+        ->default('datlechin-chatgpt.temperature', 0.7)
         ->default('datlechin-chatgpt.user_prompt_badge_text', 'Assistant')
         ->serializeToForum('chatGptUserPromptId', 'datlechin-chatgpt.user_prompt')
         ->serializeToForum('chatGptBadgeText', 'datlechin-chatgpt.user_prompt_badge_text'),

--- a/src/Api/Controller/ShowOpenAiModelsController.php
+++ b/src/Api/Controller/ShowOpenAiModelsController.php
@@ -2,7 +2,7 @@
 
 namespace Datlechin\FlarumChatGPT\Api\Controller;
 
-use Datlechin\FlarumChatGPT\OpenAIClient;
+use Flarum\OpenAI\OpenAIClient;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Cache\Store;
 use Laminas\Diactoros\Response\JsonResponse;

--- a/src/OpenAIClient.php
+++ b/src/OpenAIClient.php
@@ -3,20 +3,27 @@
 namespace Flarum\OpenAI;
 
 use OpenAI;
+use Flarum\Settings\SettingsRepositoryInterface;
 
 class OpenAIClient
 {
     private $client;
+    private $settings;
 
-    public function __construct(string $apiKey)
+    public function __construct(string $apiKey, SettingsRepositoryInterface $settings)
     {
         $this->client = OpenAI::client($apiKey);
+        $this->settings = $settings;
     }
 
-    public function completions(string $prompt, int $maxTokens = 150, float $temperature = 0.7): array
+    public function completions(string $prompt, int $maxTokens = null, float $temperature = null): array
     {
+        $model = $this->settings->get('datlechin-chatgpt.model', 'gpt-3.5-turbo');
+        $maxTokens = $maxTokens ?? (int) $this->settings->get('datlechin-chatgpt.max_tokens', 150);
+        $temperature = $temperature ?? (float) $this->settings->get('datlechin-chatgpt.temperature', 0.7);
+
         $response = $this->client->chat()->completions()->create([
-            'model' => 'gpt-3.5-turbo',
+            'model' => $model,
             'messages' => [
                 [
                     'role' => 'user',


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Migrate OpenAI API usage to `chat()->completions()` for compatibility with `openai-php/client` v0.14.0.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This update is necessary because `openai-php/client` v0.14.0 deprecates the `completions()` API. The migration involved refactoring the OpenAI client integration, updating prompt formats to structured messages, and changing the default model to `gpt-3.5-turbo`.